### PR TITLE
Added constructor to `AlgorithmParameter`

### DIFF
--- a/x509-certificate/src/rfc5280.rs
+++ b/x509-certificate/src/rfc5280.rs
@@ -102,6 +102,10 @@ impl Values for AlgorithmIdentifier {
 pub struct AlgorithmParameter(Captured);
 
 impl AlgorithmParameter {
+    pub fn from_captured(captured: Captured) -> Self {
+        Self(captured)
+    }
+
     /// Construct a new instance consisting of a single OID.
     pub fn from_oid(oid: Oid) -> Self {
         let captured = Captured::from_values(Mode::Der, oid.encode());


### PR DESCRIPTION
I ran into a limitation with `AlgorithmParameter` where it could only be created using a single `Oid`. This works fine for many cases, but I was trying to construct a certificate which contained a Subject Public Key Info for RSASSA-PSS. This scheme requires a more complicated type to be included as the the algorithm parameter, not just a single OID.