### PR TITLE
feat: implement optional reqwest depdendency for smaller deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "cryptographic-message-syntax"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "bcder",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "cryptographic-message-syntax"
-version = "0.27.0"
+version = "0.26.0"
 dependencies = [
  "bcder",
  "bytes",

--- a/cryptographic-message-syntax/Cargo.toml
+++ b/cryptographic-message-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptographic-message-syntax"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Gregory Szorc <gregory.szorc@gmail.com>"]
 edition = "2021"
 rust-version = "1.65"
@@ -17,7 +17,7 @@ bytes = "1.5.0"
 chrono = { version = "0.4.31", default-features = false }
 hex = "0.4.3"
 pem = "3.0.2"
-reqwest = { version = "0.11.22", default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.11.22", default-features = false, features = ["blocking", "rustls-tls"], optional = true }
 ring = "0.17.5"
 signature = { version = "2.1.0", features = ["std"] }
 
@@ -25,3 +25,7 @@ signature = { version = "2.1.0", features = ["std"] }
 path = "../x509-certificate"
 version = "0.23.0"
 features = ["test"]
+
+[features]
+default = ["http"]
+http = ["dep:reqwest"]

--- a/cryptographic-message-syntax/Cargo.toml
+++ b/cryptographic-message-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptographic-message-syntax"
-version = "0.27.0"
+version = "0.26.0"
 authors = ["Gregory Szorc <gregory.szorc@gmail.com>"]
 edition = "2021"
 rust-version = "1.65"

--- a/cryptographic-message-syntax/src/lib.rs
+++ b/cryptographic-message-syntax/src/lib.rs
@@ -72,17 +72,21 @@ structures referenced by RFC5652 and taught them to serialize using `bcder`.
 */
 
 pub mod asn1;
+
+#[cfg(feature = "http")]
 mod signing;
+#[cfg(feature = "http")]
 mod time_stamp_protocol;
 
+#[cfg(feature = "http")]
 pub use {
-    bcder::Oid,
-    bytes::Bytes,
     signing::{SignedDataBuilder, SignerBuilder},
     time_stamp_protocol::{
         time_stamp_message_http, time_stamp_request_http, TimeStampError, TimeStampResponse,
     },
 };
+
+pub use {bcder::Oid, bytes::Bytes};
 
 use {
     crate::asn1::{
@@ -171,6 +175,7 @@ pub enum CmsError {
     /// Error occurred parsing a distinguished name field in a certificate.
     DistinguishedNameParseError,
 
+    #[cfg(feature = "http")]
     /// Error occurred in Time-Stamp Protocol.
     TimeStampProtocol(TimeStampError),
 
@@ -228,6 +233,7 @@ impl Display for CmsError {
             Self::DistinguishedNameParseError => {
                 f.write_str("could not parse distinguished name data")
             }
+            #[cfg(feature = "http")]
             Self::TimeStampProtocol(e) => {
                 f.write_fmt(format_args!("Time-Stamp Protocol error: {}", e))
             }
@@ -256,6 +262,7 @@ impl From<PemError> for CmsError {
     }
 }
 
+#[cfg(feature = "http")]
 impl From<TimeStampError> for CmsError {
     fn from(e: TimeStampError) -> Self {
         Self::TimeStampProtocol(e)


### PR DESCRIPTION
As discussed in https://github.com/indygreg/cryptography-rs/issues/9, I've gone ahead and declared `reqwest` an optional dependency using features. By default, I've kept it as a dependency and users can opt out of using it and installing the dependencies by declaring `default-features` false.

`cryptographic-message-syntax = { version = "0.26.0", default-features = false }`