### PR TITLE
allow cms version to be set by the client api

### DIFF
--- a/cryptographic-message-syntax/src/signing.rs
+++ b/cryptographic-message-syntax/src/signing.rs
@@ -84,7 +84,7 @@ impl<'a> SignerBuilder<'a> {
                 serial_number: signing_certificate.serial_number_asn1().clone(),
             }),
             signing_certificate: Some(signing_certificate),
-            digest_algorithm: DigestAlgorithm::Sha384,
+            digest_algorithm: DigestAlgorithm::Sha256,
             message_id_content: None,
             content_type: Oid(Bytes::copy_from_slice(OID_ID_DATA.as_ref())),
             extra_signed_attributes: Vec::new(),


### PR DESCRIPTION
For MRTD projects, when creating a signed content (E.g EF.SOD) the version needs to be 3, but this cannot be set from outside. So I added the necessary fields and methods to allow cms version to be set from a client api.

```rust
  let result = SignedDataBuilder::default()
    .content_type(oid)
    .content_inline(sign_data?)
    .signer(signer)
    .cms_version(CmsVersion::V3) //--> this line
    .build_der()
    ```