### PR TITLE
Fix integer overflow panic in GeneralizedTime fractional seconds parsing

### DIFF
--- a/x509-certificate/src/asn1time.rs
+++ b/x509-certificate/src/asn1time.rs
@@ -208,6 +208,14 @@ impl GeneralizedTime {
                     {
                         let digits_count = nondigit_offset - 1;
 
+                        // GeneralizedTime fractional seconds must not exceed 9 digits (nanosecond precision)
+                        if digits_count > 9 {
+                            return Err(source.content_err(format!(
+                                "fractional seconds too precise: {} digits (maximum 9 for nanosecond precision)",
+                                digits_count
+                            )));
+                        }
+
                         let (digits, remaining) = remaining.split_at(nondigit_offset);
 
                         let mut digits = std::str::from_utf8(&digits[1..])


### PR DESCRIPTION
Fixes #74

## Summary

Adds bounds check to prevent integer underflow panic when parsing GeneralizedTime values with more than 9 fractional second digits.

## Changes

- **File**: `x509-certificate/src/asn1time.rs`
- **Change**: Add validation before padding calculation
- **Lines changed**: +8 insertions

## Problem

The current code panics when `digits_count > 9` due to integer underflow:

```rust
digits.extend(std::iter::repeat_n('0', 9 - digits_count)); // Panics if digits_count > 9
```

## Solution

Add bounds check before the subtraction:

```rust
// GeneralizedTime fractional seconds must not exceed 9 digits (nanosecond precision)
if digits_count > 9 {
    return Err(source.content_err(format!(
        "fractional seconds too precise: {} digits (maximum 9 for nanosecond precision)",
        digits_count
    )));
}
```

## Testing

- ✅ Compiles successfully (`cargo check`)
- ✅ Maintains identical behavior for valid input (≤9 digits)
- ✅ Returns proper error for invalid input (>9 digits) instead of panicking
- ✅ Discovered and validated through fuzzing

## Impact

This fix prevents denial-of-service scenarios when parsing certificates from untrusted sources. Given that the documentation explicitly states the ASN.1 parser isn't hardened against malicious inputs, this improves robustness in that known risk area.

## Crash Input Example

```
20220130204612.2013600332201~303Z
```
(13 fractional second digits → panic before fix → error after fix)